### PR TITLE
FIX: adding can_download

### DIFF
--- a/playbooks/roles/assets/tasks/main.yml
+++ b/playbooks/roles/assets/tasks/main.yml
@@ -10,7 +10,7 @@
 
 # Gather assets using paver if possible (-e 'assets=true')
 
-- name: stop {{ item }} services
+- name: stop {{ item }} services (-e 'assets_stop=true')
   supervisorctl:
     name: "{{ item }}"
     supervisorctl_path: "{{ supervisor_ctl }}"
@@ -26,6 +26,7 @@
   command: "{{ COMMON_BIN_DIR }}/edxapp-update-assets-{{ item }}"
   when: assets is defined and assets|bool
   with_items: "{{ service_variants_enabled }}"
+  no_log: True
   register: restart
   tags:
     - assets

--- a/playbooks/roles/nginx/tasks/init_config.yml
+++ b/playbooks/roles/nginx/tasks/init_config.yml
@@ -7,6 +7,7 @@
     - install
     - install:configuration
     - microsites
+
     
 - name: download microsite certificate from (server_vars)
   get_url:
@@ -15,7 +16,7 @@
     headers: "Authorization: {{ EDXAPP_MICROSITE_SECRET }}"
     mode: 0644
   with_dict: "{{ EDXAPP_MICROSITE_CONFIGURATION }}"
-  when: "{{ item.value.generate_nginx_conf }}"
+  when: "{{ item.value.generate_nginx_conf }} and {{ item.value.can_download }}"
   become: true
   tags:
     - install
@@ -29,7 +30,7 @@
     headers: "Authorization: {{ EDXAPP_MICROSITE_SECRET }}"
     mode: 0644
   with_dict: "{{ EDXAPP_MICROSITE_CONFIGURATION }}"
-  when: "{{ item.value.generate_nginx_conf }}"
+  when: "{{ item.value.generate_nginx_conf }} and {{ item.value.can_download }}"
   become: true
   tags:
     - install
@@ -58,7 +59,7 @@
      headers: "Authorization: {{ EDXAPP_MICROSITE_SECRET }}"
      mode: 0644
    with_dict: "{{ PLATFORM_EDXAPP_MICROSITE_CONFIGURATION|default({}) }}"
-   when: "{{ PLATFORM_EDXAPP_MICROSITE_CONFIGURATION is defined and item.value.generate_nginx_conf }}"
+   when: "{{ PLATFORM_EDXAPP_MICROSITE_CONFIGURATION is defined }} and {{ item.value.generate_nginx_conf }} and {{ item.value.can_download }}"
    become: true
    tags:
     - install
@@ -72,7 +73,7 @@
      headers: "Authorization: {{ EDXAPP_MICROSITE_SECRET }}"
      mode: 0644
    with_dict: "{{ PLATFORM_EDXAPP_MICROSITE_CONFIGURATION|default({}) }}"
-   when: PLATFORM_EDXAPP_MICROSITE_CONFIGURATION is defined and item.value.generate_nginx_conf
+   when: "{{ PLATFORM_EDXAPP_MICROSITE_CONFIGURATION is defined }} and {{ item.value.generate_nginx_conf }} and {{ item.value.can_download }}"
    become: true
    tags:
     - install


### PR DESCRIPTION
when the generate_nginx_conf setting is true and consola does not have the certificates for download the build fails. this will allow us to still have microsites in the config files that does not exist on consola.