### PR TITLE
ENH: simple correct reditect, catering for load balancer

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -89,6 +89,11 @@ error_page {{ k }} {{ v }};
   {% if NGINX_ENABLE_SSL or NGINX_REDIRECT_TO_HTTPS %}
   # request the browser to use SSL for all connections
   add_header Strict-Transport-Security "max-age={{ NGINX_HSTS_MAX_AGE }}";
+  
+  if ($http_x_forwarded_proto = 'http') {
+       return 301 https://$server_name$request_uri;   
+  }
+  
   {% endif %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/micro_site.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/micro_site.j2
@@ -65,6 +65,10 @@ error_page {{ k }} @maintenance;
   
   # request the browser to use SSL for all connections
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  
+  if ($http_x_forwarded_proto = 'http') {
+      return 301 https://$server_name$request_uri;   
+  }
   {% endif %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings


### PR DESCRIPTION
forcing "http_x_forwarded_proto" check on all requests to redirect to https, if ssl enabled