### PR TITLE
Proversity/load balancer override

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -10,7 +10,7 @@ if [[ "$1" == "staging" ]]; then
 	aws ec2 authorize-security-group-ingress --group-id $STAGING_SEC_GROUP --protocol tcp --port 22 --cidr "$IP/32"
 	sleep 2
 	echo "Running play to update configuration"
-	ssh ubuntu@staging.learn.proversity.io "/edx/bin/update -v configuration proversity/staging"
+	ssh ubuntu@staging.builds.proversity.io "/edx/bin/update -v configuration proversity/staging"
 	ERROR=$?
 	sleep 2
 	echo "Removing IP from EC2"

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -20,7 +20,7 @@ elif [[ "$1" == "production" ]]; then
 	aws ec2 authorize-security-group-ingress --group-id $PRODUCTION_SEC_GROUP --protocol tcp --port 22 --cidr "$IP/32"
 	sleep 2
 	echo "Running play to update configuration"
-	ssh ubuntu@studio.proversity.org "/edx/bin/update -v configuration proversity/production"
+	ssh ec2-user@nat.proversity.io ". /dev/proversity/secret-builds/configuration.sh"
 	ERROR=$?
 	sleep 2
 	echo "Removing IP from EC2"

--- a/playbooks/roles/ecommerce/meta/main.yml
+++ b/playbooks/roles/ecommerce/meta/main.yml
@@ -24,7 +24,7 @@ dependencies:
     edx_django_service_django_settings_module: '{{ ECOMMERCE_DJANGO_SETTINGS_MODULE }}'
     edx_django_service_environment_extra: '{{ ecommerce_environment }}'
     edx_django_service_gunicorn_extra: '{{ ECOMMERCE_GUNICORN_EXTRA }}'
-    edx_django_service_hostname: '{{ EDXAPP_ECOMMERCE_PUBLIC_URL_ROOT }}'
+    edx_django_service_hostname: '{{ EDXAPP_ECOMMERCE_SERVER_NAME }}'
     edx_django_service_nginx_port: '{{ ECOMMERCE_NGINX_PORT }}'
     edx_django_service_ssl_nginx_port: '{{ ECOMMERCE_SSL_NGINX_PORT }}'
     edx_django_service_use_python3: false

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -57,6 +57,8 @@ NGINX_SSL_PROTOCOLS: "TLSv1 TLSv1.1 TLSv1.2"
 NGINX_DH_PARAMS_PATH: "/etc/ssl/private/dhparams.pem"
 NGINX_DH_KEYSIZE: 2048
 
+EDXAPP_NGINX_OVERRIDE_SCHEME: '$scheme'
+
 NGINX_LOG_FORMAT_NAME: 'p_combined'
 # When set to False, nginx will pass X-Forwarded-For, X-Forwarded-Port,
 # and X-Forwarded-Proto headers through to the backend unmodified.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -159,7 +159,7 @@ error_page {{ k }} {{ v }};
 
   location @proxy_to_lms_app {
     {% if NGINX_SET_X_FORWARDED_HEADERS %}
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto {{ EDXAPP_NGINX_OVERRIDE_SCHEME }};
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Forwarded-For $remote_addr;
     {% else %}


### PR DESCRIPTION
ENH: to allow the override of the scheme sent in the headers via Nginx, for servers running behind a load balancer that does not have the certificate to run on https, this forces the https header if set,