### PR TITLE
Revert "ENH: allow to override scheme to force https behind a load balancer without a certificate"

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -57,8 +57,6 @@ NGINX_SSL_PROTOCOLS: "TLSv1 TLSv1.1 TLSv1.2"
 NGINX_DH_PARAMS_PATH: "/etc/ssl/private/dhparams.pem"
 NGINX_DH_KEYSIZE: 2048
 
-EDXAPP_NGINX_OVERRIDE_SCHEME: '$scheme'
-
 NGINX_LOG_FORMAT_NAME: 'p_combined'
 # When set to False, nginx will pass X-Forwarded-For, X-Forwarded-Port,
 # and X-Forwarded-Proto headers through to the backend unmodified.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -159,7 +159,7 @@ error_page {{ k }} {{ v }};
 
   location @proxy_to_lms_app {
     {% if NGINX_SET_X_FORWARDED_HEADERS %}
-    proxy_set_header X-Forwarded-Proto {{ EDXAPP_NGINX_OVERRIDE_SCHEME }};
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Forwarded-For $remote_addr;
     {% else %}


### PR DESCRIPTION
Reverts proversity-org/configuration#137
